### PR TITLE
Deployed Application and enabled Grouped select for Tags in new note form

### DIFF
--- a/app/javascript/src/components/Dashboard/Notes/Pane/Form.jsx
+++ b/app/javascript/src/components/Dashboard/Notes/Pane/Form.jsx
@@ -57,7 +57,6 @@ const NoteForm = ({ onClose, refetch, note, isEdit }) => {
               rows={2}
             />
             <Select
-              isMulti
               required
               className="w-full flex-grow-0"
               label="Assigned contact"
@@ -66,6 +65,7 @@ const NoteForm = ({ onClose, refetch, note, isEdit }) => {
               placeholder="Select Contact"
             />
             <Select
+              isMulti
               required
               className="w-full flex-grow-0"
               label="Tags"


### PR DESCRIPTION
Fixes #7 

@yedhink _a
Please review.


The PR also includes a minor bug that was carelessly caused in one of the previous commits. It enables a group-select feature for the tag field in the note creation form. Earlier this feature was accidentally added to the "select contact" field.